### PR TITLE
use uvx run this MCP directly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [project]
 name = "simple-openstack-mcp"
-author="choieastsea@gmail.com"
+authors = [
+    {email = "choieastsea@gmail.com"},
+]
 version = "0.1.0"
 description = "Execute openstack cli via LLMs!"
 readme = "README.md"
@@ -10,5 +12,8 @@ dependencies = [
     "python-openstackclient>=8.1.0",
 ]
 
-[project.scripts]
+[project.entry-points."console_scripts"]
 simple-openstack-mcp = "server:main"
+
+[tool.setuptools]
+py-modules = ["server", "commander"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,6 @@ dependencies = [
     "fastmcp>=2.9.2",
     "python-openstackclient>=8.1.0",
 ]
+
+[project.scripts]
+simple-openstack-mcp = "server:main"

--- a/server.py
+++ b/server.py
@@ -15,9 +15,13 @@ def exec_openstack(cmd: str) -> str:
     return OpenStackCommander.execute(cmd)
 
 
-if __name__ == "__main__":
+def main():
     clouds_yaml_path = os.path.join(os.getcwd(), "clouds.yaml")
     if os.path.exists(clouds_yaml_path):
         os.environ["OS_CLIENT_CONFIG_FILE"] = clouds_yaml_path
     print("Using clouds.yaml from:", os.environ["OS_CLIENT_CONFIG_FILE"])
     mcp.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hi, 

I've resolved some formatting issues in pyproject.toml to enable access to the OpenStack MCP directly through uvx, eliminating the need to clone the repository locally first.

```
"mcpServers": {
      "openstack": {
        "command": "uvx",
        "args": [
          "--from",
          "git+https://github.com/ogre0403/simple-openstack-mcp".
          "simple-openstack-mcp"
        ],
	"env": {
          "OS_CLOUD": "kolla-admin",
          "OS_CLIENT_CONFIG_FILE": "/work/clouds.yaml"
	}
      }
   }
```